### PR TITLE
Fix grand total count

### DIFF
--- a/data-serving/data-service/src/controllers/case.ts
+++ b/data-serving/data-service/src/controllers/case.ts
@@ -500,9 +500,7 @@ export class CasesController {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const countriesData: any = {};
             // Get total case cardinality
-            const grandTotalCount = await Day0Case.countDocuments({
-                caseStatus: ['confirmed', 'suspected'],
-            });
+            const grandTotalCount = await Day0Case.countDocuments({});
             if (grandTotalCount === 0) {
                 res.status(200).json({});
                 return;


### PR DESCRIPTION
Fix for: #47
I was counting only cases with status `confirmed` and `suspected` for the grand total count, not it count all of the cases.