### PR TITLE
[80] location data edits not saving

### DIFF
--- a/verification/curator-service/ui/src/components/CaseForm.tsx
+++ b/verification/curator-service/ui/src/components/CaseForm.tsx
@@ -179,7 +179,16 @@ const initialValuesFromCase = (
                     : undefined,
         },
         location: {
-            ...c.location,
+            geoResolution: c.location.geoResolution || '',
+            country: c.location.country || '',
+            countryISO3: c.location.countryISO3 || '',
+            location: c.location.location || '',
+            admin1: c.location.admin1 || '',
+            admin1WikiId: c.location.admin1WikiId || '',
+            admin2: c.location.admin2 || '',
+            admin2WikiId: c.location.admin2WikiId || '',
+            admin3: c.location.admin3 || '',
+            admin3WikiId: c.location.admin3WikiId || '',
             geocodeLocation: {
                 country: c.location.country,
                 countryISO3: c.location.countryISO3,
@@ -190,6 +199,12 @@ const initialValuesFromCase = (
                 admin3: c.location.admin3 || '',
                 location: c.location.location || '',
             },
+            query: c.location.query || '',
+            geometry: c.location.geometry || {
+                latitude: undefined,
+                longitude: undefined,
+            },
+            comment: c.location.comment || '',
         },
         pathogen,
         symptoms: c.symptoms ? c.symptoms.split(', ') : [],
@@ -403,6 +418,9 @@ export default function CaseForm(props: Props): JSX.Element {
         } else {
             query = [admin3, admin2, admin1, country].filter(Boolean).join(',');
         }
+        const location = [admin3, admin2, admin1, country]
+            .filter(Boolean)
+            .join(', ');
 
         const newCase: Day0Case = {
             ...values,
@@ -491,6 +509,7 @@ export default function CaseForm(props: Props): JSX.Element {
             },
             location: {
                 ...values.location,
+                location,
                 country,
                 query,
             },

--- a/verification/curator-service/ui/src/components/ViewCase.tsx
+++ b/verification/curator-service/ui/src/components/ViewCase.tsx
@@ -538,13 +538,13 @@ function CaseDetails(props: CaseDetailsProps): JSX.Element {
                             <RowContent
                                 content={`${props.c.location.geometry?.latitude?.toFixed(
                                     4,
-                                )}`}
+                                ) || ''}`}
                             />
                             <RowHeader title="Longitude" />
                             <RowContent
                                 content={`${props.c.location.geometry?.longitude?.toFixed(
                                     4,
-                                )}`}
+                                ) || ''}`}
                             />
 
                             <RowHeader title="Comment" />

--- a/verification/curator-service/ui/src/components/new-case-form-fields/Location.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/Location.tsx
@@ -486,10 +486,10 @@ export default function Location(): JSX.Element {
                             _: unknown,
                             newValue: adminEntry | null,
                         ): void => {
-                            setFieldValue('location.admin1', newValue?.name);
+                            setFieldValue('location.admin1', newValue?.name || '');
                             setFieldValue(
                                 'location.admin1WikiId',
-                                newValue?.wiki,
+                                newValue?.wiki || '',
                             );
                             setSelectedAdmin1(
                                 newValue || { name: '', wiki: '' },
@@ -588,10 +588,10 @@ export default function Location(): JSX.Element {
                             _: unknown,
                             newValue: adminEntry | null,
                         ): void => {
-                            setFieldValue('location.admin2', newValue?.name);
+                            setFieldValue('location.admin2', newValue?.name || '');
                             setFieldValue(
                                 'location.admin2WikiId',
-                                newValue?.wiki,
+                                newValue?.wiki || '',
                             );
                             setSelectedAdmin2(
                                 newValue || { name: '', wiki: '' },
@@ -690,10 +690,10 @@ export default function Location(): JSX.Element {
                             _: unknown,
                             newValue: adminEntry | null,
                         ): void => {
-                            setFieldValue('location.admin3', newValue?.name);
+                            setFieldValue('location.admin3', newValue?.name || '');
                             setFieldValue(
                                 'location.admin3WikiId',
-                                newValue?.wiki,
+                                newValue?.wiki || '',
                             );
                             setSelectedAdmin3(
                                 newValue || { name: '', wiki: '' },
@@ -703,7 +703,8 @@ export default function Location(): JSX.Element {
                             if (newInputValue === values.location.admin3)
                                 return;
                             if (reason === 'clear') {
-                                setFieldValue('location.admin3', '');
+                                console.log('CLEAR LECI');
+                                setFieldValue('location.admin3', 'aaa');
                                 setSelectedAdmin3({ name: '', wiki: '' });
                             } else {
                                 setFieldValue('location.admin3', newInputValue);

--- a/verification/curator-service/ui/src/components/new-case-form-fields/Location.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/Location.tsx
@@ -703,7 +703,7 @@ export default function Location(): JSX.Element {
                             if (newInputValue === values.location.admin3)
                                 return;
                             if (reason === 'clear') {
-                                setFieldValue('location.admin3', 'aaa');
+                                setFieldValue('location.admin3', '');
                                 setSelectedAdmin3({ name: '', wiki: '' });
                             } else {
                                 setFieldValue('location.admin3', newInputValue);

--- a/verification/curator-service/ui/src/components/new-case-form-fields/Location.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/Location.tsx
@@ -703,7 +703,6 @@ export default function Location(): JSX.Element {
                             if (newInputValue === values.location.admin3)
                                 return;
                             if (reason === 'clear') {
-                                console.log('CLEAR LECI');
                                 setFieldValue('location.admin3', 'aaa');
                                 setSelectedAdmin3({ name: '', wiki: '' });
                             } else {


### PR DESCRIPTION
Solves: #80 

Full `location` for `location` section was previously set only after geocoding. It is now based on the `admin` data and updates according to changes for `admin` data.