### PR TITLE
[FIX 122] Revert passport version to 5.3.0

### DIFF
--- a/verification/curator-service/api/package-lock.json
+++ b/verification/curator-service/api/package-lock.json
@@ -9,6 +9,10 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@types/passport": "^1.0.4",
+        "@types/passport-google-oauth20": "^2.0.4",
+        "@types/passport-http-bearer": "^1.0.36",
+        "@types/passport-local": "^1.0.33",
         "@types/swagger-ui-express": "^4.1.6",
         "aws-sdk": "^2.1631.0",
         "axios": "^1.7.2",
@@ -55,10 +59,6 @@
         "@types/lodash": "^4.17.4",
         "@types/node": "^20.12.13",
         "@types/nodemailer": "^6.4.15",
-        "@types/passport": "^1.0.16",
-        "@types/passport-google-oauth20": "^2.0.16",
-        "@types/passport-http-bearer": "^1.0.41",
-        "@types/passport-local": "^1.0.38",
         "@types/pino": "^7.0.5",
         "@types/supertest": "^6.0.2",
         "@types/yamljs": "^0.2.34",
@@ -1410,7 +1410,6 @@
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.7.tgz",
       "integrity": "sha512-Pay9fq2lM2wXPWbteBsRAGiWH2hig4ZE2asK+mm7kUzlxRTfL961rj89I6zV/E3PcIkDqyuBEcMxFT7rccugeQ==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -1485,8 +1484,7 @@
     "node_modules/@types/content-disposition": {
       "version": "0.5.8",
       "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.8.tgz",
-      "integrity": "sha512-QVSSvno3dE0MgO76pJhmv4Qyi/j0Yk9pBp0Y7TJ2Tlj+KCgJWY6qX7nnxCOLkZ3VYRSIk1WTxCvwUSdx6CCLdg==",
-      "dev": true
+      "integrity": "sha512-QVSSvno3dE0MgO76pJhmv4Qyi/j0Yk9pBp0Y7TJ2Tlj+KCgJWY6qX7nnxCOLkZ3VYRSIk1WTxCvwUSdx6CCLdg=="
     },
     "node_modules/@types/cookie-parser": {
       "version": "1.4.7",
@@ -1507,7 +1505,6 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.9.0.tgz",
       "integrity": "sha512-40Zk8qR147RABiQ7NQnBzWzDcjKzNrntB5BAmeGCb2p/MIyOE+4BVvc17wumsUqUw00bJYqoXFHYygQnEFh4/Q==",
-      "dev": true,
       "dependencies": {
         "@types/connect": "*",
         "@types/express": "*",
@@ -1593,14 +1590,12 @@
     "node_modules/@types/http-assert": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.5.tgz",
-      "integrity": "sha512-4+tE/lwdAahgZT1g30Jkdm9PzFRde0xwxBNUyRsCitRvCQB90iuA2uJYdUnhnANRcqGXaWOGY4FEoxeElNAK2g==",
-      "dev": true
+      "integrity": "sha512-4+tE/lwdAahgZT1g30Jkdm9PzFRde0xwxBNUyRsCitRvCQB90iuA2uJYdUnhnANRcqGXaWOGY4FEoxeElNAK2g=="
     },
     "node_modules/@types/http-errors": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
-      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
-      "dev": true
+      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA=="
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
@@ -1644,14 +1639,12 @@
     "node_modules/@types/keygrip": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.6.tgz",
-      "integrity": "sha512-lZuNAY9xeJt7Bx4t4dx0rYCDqGPW8RXhQZK1td7d4H6E9zYbLoOtjBvfwdTKpsyxQI/2jv+armjX/RW+ZNpXOQ==",
-      "dev": true
+      "integrity": "sha512-lZuNAY9xeJt7Bx4t4dx0rYCDqGPW8RXhQZK1td7d4H6E9zYbLoOtjBvfwdTKpsyxQI/2jv+armjX/RW+ZNpXOQ=="
     },
     "node_modules/@types/koa": {
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.15.0.tgz",
       "integrity": "sha512-7QFsywoE5URbuVnG3loe03QXuGajrnotr3gQkXcEBShORai23MePfFYdhz90FEtBBpkyIYQbVD+evKtloCgX3g==",
-      "dev": true,
       "dependencies": {
         "@types/accepts": "*",
         "@types/content-disposition": "*",
@@ -1667,7 +1660,6 @@
       "version": "3.2.8",
       "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.8.tgz",
       "integrity": "sha512-4Olc63RY+MKvxMwVknCUDhRQX1pFQoBZ/lXcRLP69PQkEpze/0cr8LNqJQe5NFb/b19DWi2a5bTi2VAlQzhJuA==",
-      "dev": true,
       "dependencies": {
         "@types/koa": "*"
       }
@@ -1718,25 +1710,22 @@
       "version": "0.9.5",
       "resolved": "https://registry.npmjs.org/@types/oauth/-/oauth-0.9.5.tgz",
       "integrity": "sha512-+oQ3C2Zx6ambINOcdIARF5Z3Tu3x//HipE889/fqo3sgpQZbe9c6ExdQFtN6qlhpR7p83lTZfPJt0tCAW29dog==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/passport": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.16.tgz",
-      "integrity": "sha512-FD0qD5hbPWQzaM0wHUnJ/T0BBCJBxCeemtnCwc/ThhTg3x9jfrAcRUmj5Dopza+MfFS9acTe3wk7rcVnRIp/0A==",
-      "dev": true,
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.4.tgz",
+      "integrity": "sha512-h5OfAbfBBYSzjeU0GTuuqYEk9McTgWeGQql9g3gUw2/NNCfD7VgExVRYJVVeU13Twn202Mvk9BT0bUrl30sEgA==",
       "dependencies": {
         "@types/express": "*"
       }
     },
     "node_modules/@types/passport-google-oauth20": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@types/passport-google-oauth20/-/passport-google-oauth20-2.0.16.tgz",
-      "integrity": "sha512-ayXK2CJ7uVieqhYOc6k/pIr5pcQxOLB6kBev+QUGS7oEZeTgIs1odDobXRqgfBPvXzl0wXCQHftV5220czZCPA==",
-      "dev": true,
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/passport-google-oauth20/-/passport-google-oauth20-2.0.4.tgz",
+      "integrity": "sha512-lYLsLzbYKlCopSO1b/FdxsBOgpIIZfvhVdVj5Wgx97udiPDGqv3g8Sq5OsWk20idtPL606SnfPRFgWfx698Nkw==",
       "dependencies": {
         "@types/express": "*",
         "@types/passport": "*",
@@ -1744,10 +1733,9 @@
       }
     },
     "node_modules/@types/passport-http-bearer": {
-      "version": "1.0.41",
-      "resolved": "https://registry.npmjs.org/@types/passport-http-bearer/-/passport-http-bearer-1.0.41.tgz",
-      "integrity": "sha512-ecW+9e8C+0id5iz3YZ+uIarsk/vaRPkKSajt1i1Am66t0mC9gDfQDKXZz9fnPOW2xKUufbmCSou4005VM94Feg==",
-      "dev": true,
+      "version": "1.0.36",
+      "resolved": "https://registry.npmjs.org/@types/passport-http-bearer/-/passport-http-bearer-1.0.36.tgz",
+      "integrity": "sha512-D6yFiojv/JSxuQY2FcT/dzFHw+ypVOkKN4QzTdt6xZyrmMQBI7p1wr5F3+clCNUgxRgoNaBVRuzlwu5NSV530w==",
       "dependencies": {
         "@types/express": "*",
         "@types/koa": "*",
@@ -1755,10 +1743,9 @@
       }
     },
     "node_modules/@types/passport-local": {
-      "version": "1.0.38",
-      "resolved": "https://registry.npmjs.org/@types/passport-local/-/passport-local-1.0.38.tgz",
-      "integrity": "sha512-nsrW4A963lYE7lNTv9cr5WmiUD1ibYJvWrpE13oxApFsRt77b0RdtZvKbCdNIY4v/QZ6TRQWaDDEwV1kCTmcXg==",
-      "dev": true,
+      "version": "1.0.33",
+      "resolved": "https://registry.npmjs.org/@types/passport-local/-/passport-local-1.0.33.tgz",
+      "integrity": "sha512-+rn6ZIxje0jZ2+DAiWFI8vGG7ZFKB0hXx2cUdMmudSWsigSq6ES7Emso46r4HJk0qCgrZVfI8sJiM7HIYf4SbA==",
       "dependencies": {
         "@types/express": "*",
         "@types/passport": "*",
@@ -1769,7 +1756,6 @@
       "version": "1.4.17",
       "resolved": "https://registry.npmjs.org/@types/passport-oauth2/-/passport-oauth2-1.4.17.tgz",
       "integrity": "sha512-ODiAHvso6JcWJ6ZkHHroVp05EHGhqQN533PtFNBkg8Fy5mERDqsr030AX81M0D69ZcaMvhF92SRckEk2B0HYYg==",
-      "dev": true,
       "dependencies": {
         "@types/express": "*",
         "@types/oauth": "*",
@@ -1780,7 +1766,6 @@
       "version": "0.2.38",
       "resolved": "https://registry.npmjs.org/@types/passport-strategy/-/passport-strategy-0.2.38.tgz",
       "integrity": "sha512-GC6eMqqojOooq993Tmnmp7AUTbbQSgilyvpCYQjT+H6JfG/g6RGc7nXEniZlp0zyKJ0WUdOiZWLBZft9Yug1uA==",
-      "dev": true,
       "dependencies": {
         "@types/express": "*",
         "@types/passport": "*"
@@ -11677,7 +11662,6 @@
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.7.tgz",
       "integrity": "sha512-Pay9fq2lM2wXPWbteBsRAGiWH2hig4ZE2asK+mm7kUzlxRTfL961rj89I6zV/E3PcIkDqyuBEcMxFT7rccugeQ==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -11752,8 +11736,7 @@
     "@types/content-disposition": {
       "version": "0.5.8",
       "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.8.tgz",
-      "integrity": "sha512-QVSSvno3dE0MgO76pJhmv4Qyi/j0Yk9pBp0Y7TJ2Tlj+KCgJWY6qX7nnxCOLkZ3VYRSIk1WTxCvwUSdx6CCLdg==",
-      "dev": true
+      "integrity": "sha512-QVSSvno3dE0MgO76pJhmv4Qyi/j0Yk9pBp0Y7TJ2Tlj+KCgJWY6qX7nnxCOLkZ3VYRSIk1WTxCvwUSdx6CCLdg=="
     },
     "@types/cookie-parser": {
       "version": "1.4.7",
@@ -11774,7 +11757,6 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.9.0.tgz",
       "integrity": "sha512-40Zk8qR147RABiQ7NQnBzWzDcjKzNrntB5BAmeGCb2p/MIyOE+4BVvc17wumsUqUw00bJYqoXFHYygQnEFh4/Q==",
-      "dev": true,
       "requires": {
         "@types/connect": "*",
         "@types/express": "*",
@@ -11859,14 +11841,12 @@
     "@types/http-assert": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.5.tgz",
-      "integrity": "sha512-4+tE/lwdAahgZT1g30Jkdm9PzFRde0xwxBNUyRsCitRvCQB90iuA2uJYdUnhnANRcqGXaWOGY4FEoxeElNAK2g==",
-      "dev": true
+      "integrity": "sha512-4+tE/lwdAahgZT1g30Jkdm9PzFRde0xwxBNUyRsCitRvCQB90iuA2uJYdUnhnANRcqGXaWOGY4FEoxeElNAK2g=="
     },
     "@types/http-errors": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
-      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
-      "dev": true
+      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA=="
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.4",
@@ -11910,14 +11890,12 @@
     "@types/keygrip": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.6.tgz",
-      "integrity": "sha512-lZuNAY9xeJt7Bx4t4dx0rYCDqGPW8RXhQZK1td7d4H6E9zYbLoOtjBvfwdTKpsyxQI/2jv+armjX/RW+ZNpXOQ==",
-      "dev": true
+      "integrity": "sha512-lZuNAY9xeJt7Bx4t4dx0rYCDqGPW8RXhQZK1td7d4H6E9zYbLoOtjBvfwdTKpsyxQI/2jv+armjX/RW+ZNpXOQ=="
     },
     "@types/koa": {
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.15.0.tgz",
       "integrity": "sha512-7QFsywoE5URbuVnG3loe03QXuGajrnotr3gQkXcEBShORai23MePfFYdhz90FEtBBpkyIYQbVD+evKtloCgX3g==",
-      "dev": true,
       "requires": {
         "@types/accepts": "*",
         "@types/content-disposition": "*",
@@ -11933,7 +11911,6 @@
       "version": "3.2.8",
       "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.8.tgz",
       "integrity": "sha512-4Olc63RY+MKvxMwVknCUDhRQX1pFQoBZ/lXcRLP69PQkEpze/0cr8LNqJQe5NFb/b19DWi2a5bTi2VAlQzhJuA==",
-      "dev": true,
       "requires": {
         "@types/koa": "*"
       }
@@ -11984,25 +11961,22 @@
       "version": "0.9.5",
       "resolved": "https://registry.npmjs.org/@types/oauth/-/oauth-0.9.5.tgz",
       "integrity": "sha512-+oQ3C2Zx6ambINOcdIARF5Z3Tu3x//HipE889/fqo3sgpQZbe9c6ExdQFtN6qlhpR7p83lTZfPJt0tCAW29dog==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/passport": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.16.tgz",
-      "integrity": "sha512-FD0qD5hbPWQzaM0wHUnJ/T0BBCJBxCeemtnCwc/ThhTg3x9jfrAcRUmj5Dopza+MfFS9acTe3wk7rcVnRIp/0A==",
-      "dev": true,
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.4.tgz",
+      "integrity": "sha512-h5OfAbfBBYSzjeU0GTuuqYEk9McTgWeGQql9g3gUw2/NNCfD7VgExVRYJVVeU13Twn202Mvk9BT0bUrl30sEgA==",
       "requires": {
         "@types/express": "*"
       }
     },
     "@types/passport-google-oauth20": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@types/passport-google-oauth20/-/passport-google-oauth20-2.0.16.tgz",
-      "integrity": "sha512-ayXK2CJ7uVieqhYOc6k/pIr5pcQxOLB6kBev+QUGS7oEZeTgIs1odDobXRqgfBPvXzl0wXCQHftV5220czZCPA==",
-      "dev": true,
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/passport-google-oauth20/-/passport-google-oauth20-2.0.4.tgz",
+      "integrity": "sha512-lYLsLzbYKlCopSO1b/FdxsBOgpIIZfvhVdVj5Wgx97udiPDGqv3g8Sq5OsWk20idtPL606SnfPRFgWfx698Nkw==",
       "requires": {
         "@types/express": "*",
         "@types/passport": "*",
@@ -12010,10 +11984,9 @@
       }
     },
     "@types/passport-http-bearer": {
-      "version": "1.0.41",
-      "resolved": "https://registry.npmjs.org/@types/passport-http-bearer/-/passport-http-bearer-1.0.41.tgz",
-      "integrity": "sha512-ecW+9e8C+0id5iz3YZ+uIarsk/vaRPkKSajt1i1Am66t0mC9gDfQDKXZz9fnPOW2xKUufbmCSou4005VM94Feg==",
-      "dev": true,
+      "version": "1.0.36",
+      "resolved": "https://registry.npmjs.org/@types/passport-http-bearer/-/passport-http-bearer-1.0.36.tgz",
+      "integrity": "sha512-D6yFiojv/JSxuQY2FcT/dzFHw+ypVOkKN4QzTdt6xZyrmMQBI7p1wr5F3+clCNUgxRgoNaBVRuzlwu5NSV530w==",
       "requires": {
         "@types/express": "*",
         "@types/koa": "*",
@@ -12021,10 +11994,9 @@
       }
     },
     "@types/passport-local": {
-      "version": "1.0.38",
-      "resolved": "https://registry.npmjs.org/@types/passport-local/-/passport-local-1.0.38.tgz",
-      "integrity": "sha512-nsrW4A963lYE7lNTv9cr5WmiUD1ibYJvWrpE13oxApFsRt77b0RdtZvKbCdNIY4v/QZ6TRQWaDDEwV1kCTmcXg==",
-      "dev": true,
+      "version": "1.0.33",
+      "resolved": "https://registry.npmjs.org/@types/passport-local/-/passport-local-1.0.33.tgz",
+      "integrity": "sha512-+rn6ZIxje0jZ2+DAiWFI8vGG7ZFKB0hXx2cUdMmudSWsigSq6ES7Emso46r4HJk0qCgrZVfI8sJiM7HIYf4SbA==",
       "requires": {
         "@types/express": "*",
         "@types/passport": "*",
@@ -12035,7 +12007,6 @@
       "version": "1.4.17",
       "resolved": "https://registry.npmjs.org/@types/passport-oauth2/-/passport-oauth2-1.4.17.tgz",
       "integrity": "sha512-ODiAHvso6JcWJ6ZkHHroVp05EHGhqQN533PtFNBkg8Fy5mERDqsr030AX81M0D69ZcaMvhF92SRckEk2B0HYYg==",
-      "dev": true,
       "requires": {
         "@types/express": "*",
         "@types/oauth": "*",
@@ -12046,7 +12017,6 @@
       "version": "0.2.38",
       "resolved": "https://registry.npmjs.org/@types/passport-strategy/-/passport-strategy-0.2.38.tgz",
       "integrity": "sha512-GC6eMqqojOooq993Tmnmp7AUTbbQSgilyvpCYQjT+H6JfG/g6RGc7nXEniZlp0zyKJ0WUdOiZWLBZft9Yug1uA==",
-      "dev": true,
       "requires": {
         "@types/express": "*",
         "@types/passport": "*"

--- a/verification/curator-service/api/package-lock.json
+++ b/verification/curator-service/api/package-lock.json
@@ -32,7 +32,7 @@
         "mongodb": "^6.7.0",
         "mongodb-memory-server": "^9.2.0",
         "nodemailer": "^6.9.13",
-        "passport": "^0.7.0",
+        "passport": "^0.5.3",
         "passport-google-oauth20": "^2.0.0",
         "passport-http-bearer": "^1.0.1",
         "passport-local": "^1.0.0",
@@ -8074,13 +8074,12 @@
       }
     },
     "node_modules/passport": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
-      "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.5.3.tgz",
+      "integrity": "sha512-gGc+70h4gGdBWNsR3FuV3byLDY6KBTJAIExGFXTpQaYfbbcHCBlRRKx7RBQSpqEqc5Hh2qVzRs7ssvSfOpkUEA==",
       "dependencies": {
         "passport-strategy": "1.x.x",
-        "pause": "0.0.1",
-        "utils-merge": "^1.0.1"
+        "pause": "0.0.1"
       },
       "engines": {
         "node": ">= 0.4.0"
@@ -16655,13 +16654,12 @@
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
     "passport": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
-      "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.5.3.tgz",
+      "integrity": "sha512-gGc+70h4gGdBWNsR3FuV3byLDY6KBTJAIExGFXTpQaYfbbcHCBlRRKx7RBQSpqEqc5Hh2qVzRs7ssvSfOpkUEA==",
       "requires": {
         "passport-strategy": "1.x.x",
-        "pause": "0.0.1",
-        "utils-merge": "^1.0.1"
+        "pause": "0.0.1"
       }
     },
     "passport-google-oauth20": {

--- a/verification/curator-service/api/package.json
+++ b/verification/curator-service/api/package.json
@@ -38,10 +38,6 @@
     "@types/lodash": "^4.17.4",
     "@types/node": "^20.12.13",
     "@types/nodemailer": "^6.4.15",
-    "@types/passport": "^1.0.16",
-    "@types/passport-google-oauth20": "^2.0.16",
-    "@types/passport-http-bearer": "^1.0.41",
-    "@types/passport-local": "^1.0.38",
     "@types/pino": "^7.0.5",
     "@types/supertest": "^6.0.2",
     "@types/yamljs": "^0.2.34",
@@ -63,6 +59,10 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
+    "@types/passport": "^1.0.4",
+    "@types/passport-google-oauth20": "^2.0.4",
+    "@types/passport-http-bearer": "^1.0.36",
+    "@types/passport-local": "^1.0.33",
     "@types/swagger-ui-express": "^4.1.6",
     "aws-sdk": "^2.1631.0",
     "axios": "^1.7.2",

--- a/verification/curator-service/api/package.json
+++ b/verification/curator-service/api/package.json
@@ -86,7 +86,7 @@
     "mongodb": "^6.7.0",
     "mongodb-memory-server": "^9.2.0",
     "nodemailer": "^6.9.13",
-    "passport": "^0.7.0",
+    "passport": "^0.5.3",
     "passport-google-oauth20": "^2.0.0",
     "passport-http-bearer": "^1.0.1",
     "passport-local": "^1.0.0",

--- a/verification/curator-service/api/src/controllers/auth.ts
+++ b/verification/curator-service/api/src/controllers/auth.ts
@@ -293,11 +293,9 @@ export class AuthController {
             },
         );
 
-        this.router.get('/logout', (req: Request, res: Response, next: NextFunction): void => {
-            req.logout(function(err) {
-                if (err) { return next(err); }
-                res.redirect('/');
-            });
+        this.router.get('/logout', function(req, res, next) {
+            req.logout();
+            res.status(200).json({ message: 'Logged out' });
         });
 
         // Starts the authentication flow with Google OAuth.

--- a/verification/curator-service/api/test/auth.test.ts
+++ b/verification/curator-service/api/test/auth.test.ts
@@ -57,8 +57,7 @@ describe('auth', () => {
         // Redirects to /
         request(app)
             .get('/auth/logout')
-            .expect(302)
-            .expect('Location', '/')
+            .expect(200)
             .end(done);
     });
     it('handles redirect from google', (done) => {
@@ -93,7 +92,7 @@ describe('bearer token auth', () => {
                 roles: ['curator'],
             })
             .expect(200, /test-user/);
-        await request.get('/auth/logout').expect(302);
+        await request.get('/auth/logout').expect(200);
         mockedAxios.get.mockResolvedValueOnce({
             data: { email: 'foo@bar.com' },
         });
@@ -111,7 +110,7 @@ describe('bearer token auth', () => {
                 roles: ['curator'],
             })
             .expect(200, /test-user/);
-        await request.get('/auth/logout').expect(302);
+        await request.get('/auth/logout').expect(200);
         mockedAxios.get.mockResolvedValueOnce({
             data: { name: 'my name' },
         });
@@ -129,7 +128,7 @@ describe('bearer token auth', () => {
                 roles: ['curator'],
             })
             .expect(200, /test-user/);
-        await request.get('/auth/logout').expect(302);
+        await request.get('/auth/logout').expect(200);
         mockedAxios.get.mockRejectedValueOnce('Oops!');
         await request
             .get('/api/sources?access_token=mF_9.B5f-4.1JqM')
@@ -229,7 +228,7 @@ describe('mustHaveAnyRole', () => {
                 roles: ['curator', 'admin'],
             })
             .expect(200, /test-curator/);
-        await request.get('/auth/logout').expect(302);
+        await request.get('/auth/logout').expect(200);
         mockedAxios.get.mockResolvedValueOnce({
             data: { email: 'foo@bar.com' },
         });
@@ -288,7 +287,7 @@ describe('api keys', () => {
         await request.post('/auth/profile/apiKey').expect(201);
         const apiKey = await request.get('/auth/profile/apiKey');
         request.set('X-API-key', apiKey.body);
-        await request.get('/auth/logout').expect(302);
+        await request.get('/auth/logout').expect(200);
         await request.get('/auth/profile').expect(200, /test-curator/);
     });
 
@@ -303,7 +302,7 @@ describe('api keys', () => {
             .expect(200, /test-curator/);
         await request.post('/auth/profile/apiKey').expect(201);
         const apiKey = await request.get('/auth/profile/apiKey');
-        await request.get('/auth/logout').expect(302);
+        await request.get('/auth/logout').expect(200);
         await request
             .post('/auth/register')
             .send({
@@ -316,7 +315,7 @@ describe('api keys', () => {
             .post(`/auth/deleteApiKey/${userRes.body._id}`)
             .expect(204);
         // now try to use the API key
-        await request.get('/auth/logout').expect(302);
+        await request.get('/auth/logout').expect(200);
         request.set('X-API-key', apiKey.body);
         await request.get('/auth/profile').expect(403);
     });
@@ -332,7 +331,7 @@ describe('api keys', () => {
             .expect(200, /test-curator/);
         await request.post('/auth/profile/apiKey').expect(201);
         const apiKey = await request.get('/auth/profile/apiKey');
-        await request.get('/auth/logout').expect(302);
+        await request.get('/auth/logout').expect(200);
         await request
             .post('/auth/register')
             .send({

--- a/verification/curator-service/ui/src/components/App/index.tsx
+++ b/verification/curator-service/ui/src/components/App/index.tsx
@@ -146,6 +146,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
 
 function ProfileMenu(props: { user: User; version: string }): JSX.Element {
     const dispatch = useAppDispatch();
+    const user = useAppSelector(selectUser);
 
     const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
 
@@ -156,6 +157,10 @@ function ProfileMenu(props: { user: User; version: string }): JSX.Element {
     const handleClose = () => {
         setAnchorEl(null);
     };
+
+    useCallback((): void => {
+        dispatch(getUserProfile());
+    }, [user]);
 
     const { classes } = menuStyles();
 

--- a/verification/curator-service/ui/src/redux/auth/slice.ts
+++ b/verification/curator-service/ui/src/redux/auth/slice.ts
@@ -157,6 +157,7 @@ const authSlice = createSlice({
         // LOGOUT
         builder.addCase(logout.fulfilled, (state) => {
             state.user = undefined;
+            localStorage.removeItem('user');
         });
 
         // CHANGE PASSWORD


### PR DESCRIPTION
Fix for #122 

Changes:
* The passport library in version 0.6.0 and above has a bug, described in [this issue](https://github.com/jaredhanson/passport/issues/1020) so it had to be reverted