### PR TITLE
[152] mongodb 5.0 end of life on october 31 2024

### DIFF
--- a/data-serving/scripts/setup-db/manual-migration-helpers/age-buckets-transition/docker-compose-test.yml
+++ b/data-serving/scripts/setup-db/manual-migration-helpers/age-buckets-transition/docker-compose-test.yml
@@ -6,6 +6,6 @@ services:
       context: .
       dockerfile: Dockerfile-test
   mongo:
-    image: mongo:5.0
+    image: mongo:6.0.17
     ports:
       - "27017:27017"

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       retries: 3
       start_period: 30s
   mongo:
-    image: mongo:5.0.6
+    image: mongo:6.0.17
     restart: always
     init: true
     ports:

--- a/dev/make_superuser.sh
+++ b/dev/make_superuser.sh
@@ -10,6 +10,6 @@ cd `dirname "$0"`
 # Pass database name as the first parameter
 DB="${GDH_DATABASE:-$1}"
 # Pass email of user to grant an admin role as second parameter
-docker-compose -f docker-compose.yml -f docker-compose.dev.yml exec mongo mongo "${DB}" --eval "var email='$2'; var roles=['admin', 'curator'];" /verification/scripts/roles.js
+docker-compose -f docker-compose.yml -f docker-compose.dev.yml exec mongo mongosh "${DB}" --eval "var email='$2'; var roles=['admin', 'curator'];" /verification/scripts/roles.js
 # Restore directory.
 popd

--- a/geocoding/location-service/docker-compose-test.yml
+++ b/geocoding/location-service/docker-compose-test.yml
@@ -6,6 +6,6 @@ services:
       context: .
       dockerfile: Dockerfile-test
   mongo:
-    image: mongo:5.0
+    image: mongo:6.0.17
     ports:
       - "27017:27017"


### PR DESCRIPTION
Solves: #152 

Changes:
* Update the version of MongoDB for main local deployment (`dev/docker-compose.yml`)
* Update the `dev/make_superuser.sh` for new version of MongoDB
* Update the rest of the MongoDB containers for other services