### PR TITLE
[98] add query for curator comments

### DIFF
--- a/data-serving/data-service/src/controllers/case.ts
+++ b/data-serving/data-service/src/controllers/case.ts
@@ -436,7 +436,7 @@ export class CasesController {
         logger.debug('Got past 422s');
         try {
             const casesQuery = casesMatchingSearchQuery({
-                searchQuery: decodeURIComponent(req.query.q || ''),
+                searchQuery: req.query.q || '',
                 count: false,
                 verificationStatus: verificationStatus,
             }) as Query<CaseDocument[], CaseDocument, unknown>;

--- a/data-serving/data-service/src/controllers/case.ts
+++ b/data-serving/data-service/src/controllers/case.ts
@@ -441,7 +441,7 @@ export class CasesController {
                 verificationStatus: verificationStatus,
             }) as Query<CaseDocument[], CaseDocument, unknown>;
             const countQuery = casesMatchingSearchQuery({
-                searchQuery: decodeURIComponent(req.query.q || ''),
+                searchQuery: req.query.q || '',
                 count: true,
                 verificationStatus: verificationStatus,
             });

--- a/data-serving/data-service/src/controllers/case.ts
+++ b/data-serving/data-service/src/controllers/case.ts
@@ -436,12 +436,12 @@ export class CasesController {
         logger.debug('Got past 422s');
         try {
             const casesQuery = casesMatchingSearchQuery({
-                searchQuery: req.query.q || '',
+                searchQuery: decodeURIComponent(req.query.q || ''),
                 count: false,
                 verificationStatus: verificationStatus,
             }) as Query<CaseDocument[], CaseDocument, unknown>;
             const countQuery = casesMatchingSearchQuery({
-                searchQuery: req.query.q || '',
+                searchQuery: decodeURIComponent(req.query.q || ''),
                 count: true,
                 verificationStatus: verificationStatus,
             });

--- a/data-serving/scripts/setup-db/schemas/day0cases.indexes.json
+++ b/data-serving/scripts/setup-db/schemas/day0cases.indexes.json
@@ -8,7 +8,8 @@
             "location.admin2": "text",
             "location.admin3": "text",
             "caseReference.sourceUrl": "text",
-            "caseStatus": "text"
+            "caseStatus": "text",
+            "comment": "text"
         }
     },
     {
@@ -139,6 +140,16 @@
         "name": "caseStatusIdx",
         "key": {
             "caseStatus": -1
+        },
+        "collation": {
+            "locale": "en_US",
+            "strength": 2
+        }
+    },
+    {
+        "name": "commentIdx",
+        "key": {
+            "comment": -1
         },
         "collation": {
             "locale": "en_US",

--- a/verification/curator-service/ui/cypress/e2e/components/LinelistTableTest.spec.ts
+++ b/verification/curator-service/ui/cypress/e2e/components/LinelistTableTest.spec.ts
@@ -501,6 +501,7 @@ describe('Linelist table', function () {
             sourceUrl: 'www.example.com',
             caseStatus: CaseStatus.Confirmed,
             occupation: 'Actor',
+            comment: 'note',
         });
         cy.addCase({
             country: 'Germany',
@@ -524,6 +525,7 @@ describe('Linelist table', function () {
         cy.intercept('GET', getDefaultQuery({ limit: 50 })).as('getCases');
         cy.intercept('GET', getDefaultQuery({ limit: 50, query: 'Argentina' })).as('getCasesWithSearch1');
         cy.intercept('GET', getDefaultQuery({ limit: 50, query: 'Doctor' })).as('getCasesWithSearch2');
+        cy.intercept('GET', getDefaultQuery({ limit: 50, query: 'note' })).as('getCasesWithSearch3');
 
         cy.visit('/cases');
         cy.wait('@getCases');
@@ -549,5 +551,30 @@ describe('Linelist table', function () {
         cy.contains('Argentina').should('not.exist');
         cy.contains('France').should('not.exist');
         cy.contains('Germany').should('exist');
+
+        cy.get('#clear-search').click();
+        cy.wait('@getCases');
+        cy.contains('Argentina').should('exist');
+        cy.contains('France').should('exist');
+        cy.contains('Germany').should('exist');
+
+        cy.get('#search-field').type('note');
+        cy.wait('@getCasesWithSearch3');
+        cy.contains('Argentina').should('not.exist');
+        cy.contains('France').should('exist');
+        cy.contains('Germany').should('not.exist');
+    });
+
+    it('Informs user when uneven number of quotes is present in free-text search', () => {
+        cy.intercept('GET', getDefaultQuery({ limit: 50, query: '"Bus driver"' })).as('getCasesWithSearch');
+        cy.visit('/cases');
+        cy.contains('Please make sure you have an even number of quotes.').should('not.exist');
+
+        cy.get('#search-field').type('"Bus driver');
+        cy.contains('Please make sure you have an even number of quotes.').should('exist');
+
+        cy.get('#search-field').type('"');
+        cy.wait('@getCasesWithSearch');
+        cy.contains('Please make sure you have an even number of quotes.').should('not.exist');
     });
 });

--- a/verification/curator-service/ui/cypress/support/commands.ts
+++ b/verification/curator-service/ui/cypress/support/commands.ts
@@ -43,6 +43,7 @@ interface AddCaseProps {
     gender?: Gender;
     outcome?: Outcome;
     uploadIds?: string[];
+    comment?: string;
 }
 
 declare global {
@@ -111,6 +112,7 @@ export function addCase(opts: AddCaseProps): void {
             travelHistory: {},
             genomeSequences: {},
             vaccination: {},
+            comment: opts.comment || '',
         },
     });
 }

--- a/verification/curator-service/ui/src/components/App/index.tsx
+++ b/verification/curator-service/ui/src/components/App/index.tsx
@@ -328,7 +328,6 @@ export default function App(): JSX.Element {
 
     const onModalClose = (): void => {
         const searchQueryObject = new URLSearchParams(searchQuery);
-
         navigate(
             {
                 pathname:

--- a/verification/curator-service/ui/src/components/App/index.tsx
+++ b/verification/curator-service/ui/src/components/App/index.tsx
@@ -380,6 +380,7 @@ export default function App(): JSX.Element {
         )
             return;
 
+        dispatch(setSearchQuery(decodeURIComponent(location.search)));
 
         // Save searchQuery to local storage not to lost it when user goes through auth process
         localStorage.setItem('searchQuery', location.search);

--- a/verification/curator-service/ui/src/components/App/index.tsx
+++ b/verification/curator-service/ui/src/components/App/index.tsx
@@ -371,7 +371,7 @@ export default function App(): JSX.Element {
         )
             return;
 
-        dispatch(setSearchQuery(location.search));
+        dispatch(setSearchQuery(decodeURI(location.search)));
 
         // Save searchQuery to local storage not to lost it when user goes through auth process
         localStorage.setItem('searchQuery', location.search);

--- a/verification/curator-service/ui/src/components/App/index.tsx
+++ b/verification/curator-service/ui/src/components/App/index.tsx
@@ -327,14 +327,7 @@ export default function App(): JSX.Element {
     };
 
     const onModalClose = (): void => {
-        let parsedSearchQuery: string = '';
-        if (searchQuery.includes('?q=')) {
-            parsedSearchQuery = `?q=${encodeURIComponent(searchQuery.split('?q=')[1])}`;
-        } else if (searchQuery.includes('&q=')) {
-            parsedSearchQuery = `${searchQuery.split('&q=')[0]}&q=${encodeURIComponent(searchQuery.split('&q=')[1])}`;
-        } else {
-            parsedSearchQuery = searchQuery;
-        }
+        const searchQueryObject = new URLSearchParams(searchQuery);
 
         navigate(
             {
@@ -342,7 +335,7 @@ export default function App(): JSX.Element {
                     location.state && location.state.lastLocation
                         ? location.state.lastLocation
                         : '/cases',
-                search: parsedSearchQuery,
+                search: searchQueryObject.toString(),
             },
             { state: { lastLocation: '/case/view' } },
         );
@@ -380,7 +373,8 @@ export default function App(): JSX.Element {
         )
             return;
 
-        dispatch(setSearchQuery(decodeURIComponent(location.search)));
+        const searchParams = new URLSearchParams(location.search);
+        dispatch(setSearchQuery(searchParams.toString()));
 
         // Save searchQuery to local storage not to lost it when user goes through auth process
         localStorage.setItem('searchQuery', location.search);

--- a/verification/curator-service/ui/src/components/App/index.tsx
+++ b/verification/curator-service/ui/src/components/App/index.tsx
@@ -327,13 +327,22 @@ export default function App(): JSX.Element {
     };
 
     const onModalClose = (): void => {
+        let parsedSearchQuery: string = '';
+        if (searchQuery.includes('?q=')) {
+            parsedSearchQuery = `?q=${encodeURIComponent(searchQuery.split('?q=')[1])}`;
+        } else if (searchQuery.includes('&q=')) {
+            parsedSearchQuery = `${searchQuery.split('&q=')[0]}&q=${encodeURIComponent(searchQuery.split('&q=')[1])}`;
+        } else {
+            parsedSearchQuery = searchQuery;
+        }
+
         navigate(
             {
                 pathname:
                     location.state && location.state.lastLocation
                         ? location.state.lastLocation
                         : '/cases',
-                search: searchQuery,
+                search: parsedSearchQuery,
             },
             { state: { lastLocation: '/case/view' } },
         );
@@ -371,7 +380,6 @@ export default function App(): JSX.Element {
         )
             return;
 
-        dispatch(setSearchQuery(decodeURI(location.search)));
 
         // Save searchQuery to local storage not to lost it when user goes through auth process
         localStorage.setItem('searchQuery', location.search);

--- a/verification/curator-service/ui/src/components/DataGuideDialog.tsx
+++ b/verification/curator-service/ui/src/components/DataGuideDialog.tsx
@@ -1,7 +1,18 @@
 import React, { useEffect } from 'react';
-import { Box, Portal, Theme, Typography } from '@mui/material';
+import {
+    Accordion,
+    AccordionDetails,
+    AccordionSummary,
+    Box,
+    Portal,
+    Theme,
+    Typography,
+} from '@mui/material';
 import { withStyles } from 'tss-react/mui';
-import CloseIcon from '@mui/icons-material/Close';
+import {
+    Close as CloseIcon,
+    ExpandMore as ExpandMoreIcon,
+} from '@mui/icons-material';
 import Draggable, { ControlPosition } from 'react-draggable';
 
 // As per this issue from react-draggable library: https://github.com/react-grid-layout/react-draggable/pull/648
@@ -96,16 +107,49 @@ const SearchGuideDialog = ({
                             the left and choose ascending or descending.
                         </Typography>
                         <Typography className={classes?.textSection}>
-                            <strong>For full-text search</strong>, enter any combination of search terms.
-                            <br/>
-                            Full-text search covers: occupation, admin0, admin1, admin2, admin3, sourceUrl and caseStatus.
-                            <br/>
-                            Search terms must be exact (example: "German" will not match "Germany").
-                            <br/>
-                            Full-text search matches cases that contain any ot the search terms, not a combination.
-                            <br/>
-                            No special characters apart from "." are allowed and if the "." is used in a search term
-                            given search term must be contained within quotation marks.
+                            <strong>For full-text search</strong>, enter any
+                            combination of search terms.
+                            Rules for full-text search:
+                            <br />
+                            <ul>
+                                <li>
+                                    Full-text search covers: occupation, admin0,
+                                    admin1, admin2, admin3, sourceUrl, comment
+                                    and caseStatus.
+                                </li>
+                                <li>
+                                    Search terms must be exact (example:{' '}
+                                    <b>
+                                        <i>German</i>
+                                    </b>{' '}
+                                    will not match{' '}
+                                    <b>
+                                        <i>Germany</i>
+                                    </b>
+                                    ).
+                                </li>
+                                <li>
+                                    Full-text search matches cases that contain
+                                    any of the search terms, not a combination.
+                                </li>
+                                <li>
+                                    To search for a combination of terms, wrap
+                                    the combination in quotation marks (example:{' '}
+                                    <b>
+                                        <i>"Bus driver"</i>
+                                    </b>
+                                    ).
+                                </li>
+                                <li>
+                                    No special characters apart from dot are
+                                    allowed. Search terms with dot must be
+                                    contained within quotation marks (example:{' '}
+                                    <b>
+                                        <i>"global.health"</i>
+                                    </b>
+                                    ).
+                                </li>
+                            </ul>
                         </Typography>
                         <Typography>
                             You can use the icons on the right to navigate

--- a/verification/curator-service/ui/src/components/DataGuideDialog.tsx
+++ b/verification/curator-service/ui/src/components/DataGuideDialog.tsx
@@ -1,18 +1,7 @@
 import React, { useEffect } from 'react';
-import {
-    Accordion,
-    AccordionDetails,
-    AccordionSummary,
-    Box,
-    Portal,
-    Theme,
-    Typography,
-} from '@mui/material';
+import { Box, Portal, Theme, Typography } from '@mui/material';
 import { withStyles } from 'tss-react/mui';
-import {
-    Close as CloseIcon,
-    ExpandMore as ExpandMoreIcon,
-} from '@mui/icons-material';
+import { Close as CloseIcon } from '@mui/icons-material';
 import Draggable, { ControlPosition } from 'react-draggable';
 
 // As per this issue from react-draggable library: https://github.com/react-grid-layout/react-draggable/pull/648
@@ -108,8 +97,8 @@ const SearchGuideDialog = ({
                         </Typography>
                         <Typography className={classes?.textSection}>
                             <strong>For full-text search</strong>, enter any
-                            combination of search terms.
-                            Rules for full-text search:
+                            combination of search terms. Rules for full-text
+                            search:
                             <br />
                             <ul>
                                 <li>

--- a/verification/curator-service/ui/src/components/FiltersDialog/index.tsx
+++ b/verification/curator-service/ui/src/components/FiltersDialog/index.tsx
@@ -17,7 +17,7 @@ import {
     useMediaQuery,
 } from '@mui/material';
 import { Close as CloseIcon } from '@mui/icons-material';
-import { filtersToURL, URLToFilters } from '../util/searchQuery';
+import { URLToFilters } from '../util/searchQuery';
 import { hasAnyRole } from '../util/helperFunctions';
 import { useAppSelector, useAppDispatch } from '../../hooks/redux';
 import { fetchCountries } from '../../redux/filters/thunk';

--- a/verification/curator-service/ui/src/components/FiltersDialog/index.tsx
+++ b/verification/curator-service/ui/src/components/FiltersDialog/index.tsx
@@ -153,11 +153,13 @@ export default function FiltersDialog({
             handleSetModalAlert();
             dispatch(setModalOpen(false));
 
-
             const searchParams = new URLSearchParams();
             for (const [key, value] of Object.entries(values)) {
+                console.log(key, value)
                 if (value) searchParams.set(key, value);
             }
+            const q = (new URLSearchParams(location.search)).get('q')
+            if (q) searchParams.set('q', q);
             const searchParamsString = searchParams.toString();
 
             sendCustomGtmEvent('filters_applied', { query: searchParamsString });

--- a/verification/curator-service/ui/src/components/FiltersDialog/index.tsx
+++ b/verification/curator-service/ui/src/components/FiltersDialog/index.tsx
@@ -155,7 +155,6 @@ export default function FiltersDialog({
 
             const searchParams = new URLSearchParams();
             for (const [key, value] of Object.entries(values)) {
-                console.log(key, value)
                 if (value) searchParams.set(key, value);
             }
             const q = (new URLSearchParams(location.search)).get('q')

--- a/verification/curator-service/ui/src/components/FiltersDialog/index.tsx
+++ b/verification/curator-service/ui/src/components/FiltersDialog/index.tsx
@@ -153,18 +153,18 @@ export default function FiltersDialog({
             handleSetModalAlert();
             dispatch(setModalOpen(false));
 
-            let searchQuery = filtersToURL(values);
 
-            if (location.search.includes('?q=')) {
-                const q = new URLSearchParams(location.search).get('q');
-                searchQuery = `${searchQuery}&q=${q}`
+            const searchParams = new URLSearchParams();
+            for (const [key, value] of Object.entries(values)) {
+                if (value) searchParams.set(key, value);
             }
+            const searchParamsString = searchParams.toString();
 
-            sendCustomGtmEvent('filters_applied', { query: searchQuery });
+            sendCustomGtmEvent('filters_applied', { query: searchParamsString });
 
             navigate({
                 pathname: '/cases',
-                search: searchQuery,
+                search: searchParamsString,
             });
         },
     });

--- a/verification/curator-service/ui/src/components/FiltersDialog/index.tsx
+++ b/verification/curator-service/ui/src/components/FiltersDialog/index.tsx
@@ -153,7 +153,12 @@ export default function FiltersDialog({
             handleSetModalAlert();
             dispatch(setModalOpen(false));
 
-            const searchQuery = filtersToURL(values);
+            let searchQuery = filtersToURL(values);
+
+            if (location.search.includes('?q=')) {
+                const q = new URLSearchParams(location.search).get('q');
+                searchQuery = `${searchQuery}&q=${q}`
+            }
 
             sendCustomGtmEvent('filters_applied', { query: searchQuery });
 

--- a/verification/curator-service/ui/src/components/SearchBar.tsx
+++ b/verification/curator-service/ui/src/components/SearchBar.tsx
@@ -179,7 +179,6 @@ export default function SearchBar({
             return 'Incorrect entry. ":" characters have been removed. Please use filters instead.';
         } else {
             const quoteCount = decodeURI(searchInput).split('"').length - 1;
-            console.log(searchInput, quoteCount);
             if (quoteCount % 2 !== 0) {
                 return 'Incorrect entry. Please make sure you have an even number of quotes.';
             }

--- a/verification/curator-service/ui/src/components/SearchBar.tsx
+++ b/verification/curator-service/ui/src/components/SearchBar.tsx
@@ -84,11 +84,7 @@ export default function SearchBar({
     const [isUserTyping, setIsUserTyping] = useState<boolean>(false);
     const [isDataGuideOpen, setIsDataGuideOpen] = useState<boolean>(false);
     const [searchInput, setSearchInput] = useState<string>(
-        location.search.includes('?q=')
-            ? location.search.split('?q=')[1]
-            : location.search?.includes('&q=')
-              ? location.search.split('&q=')[1]
-              : '',
+        new URLSearchParams(location.search).get('q') || '',
     );
     const [modalAlert, setModalAlert] = useState<boolean>(false);
     const guideButtonRef = React.useRef<HTMLButtonElement>(null);
@@ -105,13 +101,12 @@ export default function SearchBar({
     }, [filtersBreadcrumb]);
 
     useEffect(() => {
-        const q = (new URLSearchParams(location.search)).get('q') || '';
+        const q = new URLSearchParams(location.search).get('q') || '';
         if (q !== searchInput) setSearchInput(q);
     }, [location.search]);
 
     // Set search query debounce to 1000ms
     const debouncedSearch = useDebounce(searchInput, 2000);
-
 
     const handleNavigating = (q: string) => {
         const searchParams = new URLSearchParams(location.search);
@@ -121,7 +116,7 @@ export default function SearchBar({
             pathname: '/cases',
             search: searchParams.toString(),
         });
-    }
+    };
 
     // Apply filter parameters after delay
     useEffect(() => {
@@ -180,7 +175,7 @@ export default function SearchBar({
         if (searchError) {
             return 'Incorrect entry. ":" characters have been removed. Please use filters instead.';
         } else {
-            const quoteCount = decodeURIComponent(searchInput).split('"').length - 1;
+            const quoteCount = searchInput.split('"').length - 1;
             if (quoteCount % 2 !== 0) {
                 return 'Incorrect entry. Please make sure you have an even number of quotes.';
             }

--- a/verification/curator-service/ui/src/components/SearchBar.tsx
+++ b/verification/curator-service/ui/src/components/SearchBar.tsx
@@ -106,15 +106,8 @@ export default function SearchBar({
     }, [filtersBreadcrumb]);
 
     useEffect(() => {
-        const q = location.search.includes('?q=')
-            ? location.search.split('?q=')[1]
-            : location.search?.includes('&q=')
-              ? location.search.split('&q=')[1]
-              : '';
-        const decodedQ = decodeURIComponent(q);
-        if (decodedQ !== searchInput) {
-            setSearchInput(decodedQ);
-        }
+        const q = (new URLSearchParams(location.search)).get('q') || '';
+        if (q !== searchInput) setSearchInput(q);
     }, [location.search]);
 
     // Set search query debounce to 1000ms
@@ -123,11 +116,8 @@ export default function SearchBar({
 
     const handleNavigating = (q: string) => {
         const searchParams = new URLSearchParams(location.search);
-        if (q !== '') {
-            searchParams.set('q', q);
-        } else {
-            searchParams.delete('q');
-        }
+        q !== '' ? searchParams.set('q', q) : searchParams.delete('q');
+
         navigate({
             pathname: '/cases',
             search: searchParams.toString(),

--- a/verification/curator-service/ui/src/components/SearchBar.tsx
+++ b/verification/curator-service/ui/src/components/SearchBar.tsx
@@ -174,16 +174,25 @@ export default function SearchBar({
         return searchStringStrippedOutColon;
     }
 
+    const renderSearchErrorMessage = () => {
+        if (searchError) {
+            return 'Incorrect entry. ":" characters have been removed. Please use filters instead.';
+        } else {
+            const quoteCount = decodeURI(searchInput).split('"').length - 1;
+            console.log(searchInput, quoteCount);
+            if (quoteCount % 2 !== 0) {
+                return 'Incorrect entry. Please make sure you have an even number of quotes.';
+            }
+        }
+    };
+
     return (
         <>
             <div className={classes.searchRoot}>
                 <StyledSearchTextField
                     size="small"
                     error={searchError}
-                    helperText={
-                        searchError &&
-                        'Incorrect entry. ":" characters have been removed. Please use filters instead.'
-                    }
+                    helperText={renderSearchErrorMessage()}
                     id="search-field"
                     data-testid="searchbar"
                     name="searchbar"

--- a/verification/curator-service/ui/src/components/SearchBar.tsx
+++ b/verification/curator-service/ui/src/components/SearchBar.tsx
@@ -15,7 +15,6 @@ import clsx from 'clsx';
 import DataGuideDialog from './DataGuideDialog';
 import { useDebounce } from '../hooks/useDebounce';
 import FiltersDialog from './FiltersDialog';
-import { searchQueryToURL, URLToSearchQuery } from './util/searchQuery';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { KeyboardEvent, ChangeEvent } from 'react';
 import { useAppSelector, useAppDispatch } from '../hooks/redux';

--- a/verification/curator-service/ui/src/components/SearchBar.tsx
+++ b/verification/curator-service/ui/src/components/SearchBar.tsx
@@ -122,42 +122,16 @@ export default function SearchBar({
 
 
     const handleNavigating = (q: string) => {
-        const encodedQ = encodeURIComponent(q);
-        if (encodedQ === '') {
-            if (location.search.includes('?q=')) {
-                navigate({
-                    pathname: '/cases',
-                    search: '',
-                });
-            } else if(location.search.includes('&q=')) {
-                navigate({
-                    pathname: '/cases',
-                    search: location.search.split('&q=')[0],
-                });
-            } else {
-                navigate({
-                    pathname: '/cases',
-                    search: location.search,
-                });
-            }
+        const searchParams = new URLSearchParams(location.search);
+        if (q !== '') {
+            searchParams.set('q', q);
         } else {
-            if (location.search.includes('?q=') || location.search === '') {
-                navigate({
-                    pathname: '/cases',
-                    search: `?q=${encodedQ}`,
-                });
-            } else if(location.search.includes('&q=')) {
-                navigate({
-                    pathname: '/cases',
-                    search: `${location.search.split('&q=')[0]}&q=${encodedQ}`,
-                });
-            } else {
-                navigate({
-                    pathname: '/cases',
-                    search: `${location.search}&q=${encodedQ}`,
-                });
-            }
+            searchParams.delete('q');
         }
+        navigate({
+            pathname: '/cases',
+            search: searchParams.toString(),
+        });
     }
 
     // Apply filter parameters after delay

--- a/verification/curator-service/ui/src/components/ViewCase.tsx
+++ b/verification/curator-service/ui/src/components/ViewCase.tsx
@@ -966,36 +966,28 @@ function RowContent(props: {
     linkComment?: string;
 }): JSX.Element {
     const searchQuery = useSelector(selectSearchQuery);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const searchQueryArray: any[] = [];
+    const searchQueryArray: string[] = [];
 
     function words(s: string) {
-        if (s.startsWith('?q=')) {
-            s = s.substring(3)
-        }
-        const quoted: string[] = []
-        const notQuoted: string[] = []
-        if (s.includes('"') && s.replace(/[^"]/g, "").length % 2 !== 1) {
+        if (s.startsWith('?q=')) s = s.substring(3);
+
+        const quoted: string[] = [];
+        const notQuoted: string[] = [];
+        if (s.includes('"') && s.replace(/[^"]/g, '').length % 2 !== 1) {
             s.split('"').map((subs: string, i: number) => {
-                if (i % 2) {
-                    if (subs != "") quoted.push(subs)
-                } else {
-                    if (subs != "") notQuoted.push(subs)
-                }
-
+                subs != '' && i % 2 ? quoted.push(subs) : notQuoted.push(subs);
             });
-        } else {
-            notQuoted.push(s)
-        }
-        const regex = /"([^"]+)"|(\w{1,})/g;
+        } else notQuoted.push(s);
 
+        const regex = /"([^"]+)"|(\w{1,})/g;
+        // Make sure that terms in quotes will be highlighted as one search term
         for (const quotedEntry of quoted) {
             let match;
-            let accumulator = [];
+            let accumulator: string[] = [];
             while ((match = regex.exec(quotedEntry))) {
                 accumulator.push(match[match[1] ? 1 : 2]);
             }
-            searchQueryArray.push(accumulator.join(' '))
+            searchQueryArray.push(accumulator.join(' '));
         }
         for (const notQuotedEntry of notQuoted) {
             let match;

--- a/verification/curator-service/ui/src/components/ViewCase.tsx
+++ b/verification/curator-service/ui/src/components/ViewCase.tsx
@@ -1,6 +1,19 @@
+import axios from 'axios';
 import React, { useEffect, useState } from 'react';
+import Highlighter from 'react-highlight-words';
+import { useSelector } from 'react-redux';
+import { Link, useParams } from 'react-router-dom';
+import Scroll from 'react-scroll';
+import { makeStyles } from 'tss-react/mui';
 import {
+    CheckCircleOutline as CheckIcon,
+    Close as CloseIcon,
+    EditOutlined as EditIcon,
+} from '@mui/icons-material';
+import {
+    Alert,
     Button,
+    Chip,
     Dialog,
     DialogContent,
     DialogTitle,
@@ -9,30 +22,20 @@ import {
     LinearProgress,
     Paper,
     Typography,
+    useMediaQuery,
 } from '@mui/material';
-import { Day0Case, Outcome, YesNo } from '../api/models/Day0Case';
-import AppModal from './AppModal';
-import EditIcon from '@mui/icons-material/EditOutlined';
-import CheckIcon from '@mui/icons-material/CheckCircleOutline';
-import { Link, useParams } from 'react-router-dom';
-import MuiAlert from '@mui/material/Alert';
-import Scroll from 'react-scroll';
-import axios from 'axios';
-import createHref from './util/links';
-import { makeStyles } from 'tss-react/mui';
-import renderDate from './util/date';
-import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
-import Highlighter from 'react-highlight-words';
-import { useSelector } from 'react-redux';
+
+import { Day0Case, Outcome, YesNo } from '../api/models/Day0Case';
+import { Role } from '../api/models/User';
+import AppModal from './AppModal';
+import renderDate from './util/date';
+import createHref from './util/links';
 import { selectFilterBreadcrumbs } from '../redux/app/selectors';
+import { selectUser } from '../redux/auth/selectors';
 import { selectSearchQuery } from '../redux/linelistTable/selectors';
-import Chip from '@mui/material/Chip';
 import { nameCountry } from './util/countryNames';
 import { parseAgeRange } from './util/helperFunctions';
-import CloseIcon from '@mui/icons-material/Close';
-import { selectUser } from '../redux/auth/selectors';
-import { Role } from '../api/models/User';
 
 const styles = makeStyles()(() => ({
     errorMessage: {
@@ -98,14 +101,14 @@ export default function ViewCase(props: Props): JSX.Element {
         <AppModal title="Case details" onModalClose={props.onModalClose}>
             {loading && <LinearProgress />}
             {errorMessage && (
-                <MuiAlert
+                <Alert
                     className={classes.errorMessage}
                     elevation={6}
                     variant="filled"
                     severity="error"
                 >
                     {errorMessage}
-                </MuiAlert>
+                </Alert>
             )}
             {c && (
                 <CaseDetails
@@ -969,7 +972,7 @@ function RowContent(props: {
     const searchQueryArray: string[] = [];
 
     function words(s: string) {
-        const q =  (new URLSearchParams(s)).get('q');
+        const q = new URLSearchParams(s).get('q');
         if (!q) return;
 
         const quoted: string[] = [];

--- a/verification/curator-service/ui/src/components/ViewCase.tsx
+++ b/verification/curator-service/ui/src/components/ViewCase.tsx
@@ -987,7 +987,7 @@ function RowContent(props: {
         } else {
             notQuoted.push(s)
         }
-        const regex = /"([^"]+)"|(\w{3,})/g;
+        const regex = /"([^"]+)"|(\w{1,})/g;
 
         for (const quotedEntry of quoted) {
             let match;

--- a/verification/curator-service/ui/src/components/ViewCase.tsx
+++ b/verification/curator-service/ui/src/components/ViewCase.tsx
@@ -970,12 +970,39 @@ function RowContent(props: {
     const searchQueryArray: any[] = [];
 
     function words(s: string) {
-        const regex = /"([^"]+)"|(\w{3,})/g;
-        let match;
-        while ((match = regex.exec(s))) {
-            searchQueryArray.push(match[match[1] ? 1 : 2]);
+        if (s.startsWith('?q=')) {
+            s = s.substring(3)
         }
-        return searchQueryArray;
+        const quoted: string[] = []
+        const notQuoted: string[] = []
+        if (s.includes('"') && s.replace(/[^"]/g, "").length % 2 !== 1) {
+            s.split('"').map((subs: string, i: number) => {
+                if (i % 2) {
+                    if (subs != "") quoted.push(subs)
+                } else {
+                    if (subs != "") notQuoted.push(subs)
+                }
+
+            });
+        } else {
+            notQuoted.push(s)
+        }
+        const regex = /"([^"]+)"|(\w{3,})/g;
+
+        for (const quotedEntry of quoted) {
+            let match;
+            let accumulator = [];
+            while ((match = regex.exec(quotedEntry))) {
+                accumulator.push(match[match[1] ? 1 : 2]);
+            }
+            searchQueryArray.push(accumulator.join(' '))
+        }
+        for (const notQuotedEntry of notQuoted) {
+            let match;
+            while ((match = regex.exec(notQuotedEntry))) {
+                searchQueryArray.push(match[match[1] ? 1 : 2]);
+            }
+        }
     }
     words(searchQuery);
 

--- a/verification/curator-service/ui/src/components/ViewCase.tsx
+++ b/verification/curator-service/ui/src/components/ViewCase.tsx
@@ -969,17 +969,16 @@ function RowContent(props: {
     const searchQueryArray: string[] = [];
 
     function words(s: string) {
-        if (s.includes('&q=')) {
-            s = s.split('&q=')[1];
-        } else if (s.includes('?q=')) s = s.substring(3);
+        const q =  (new URLSearchParams(s)).get('q');
+        if (!q) return;
 
         const quoted: string[] = [];
         const notQuoted: string[] = [];
-        if (s.includes('"') && s.replace(/[^"]/g, '').length % 2 !== 1) {
-            s.split('"').map((subs: string, i: number) => {
+        if (q.includes('"') && q.replace(/[^"]/g, '').length % 2 !== 1) {
+            q.split('"').map((subs: string, i: number) => {
                 subs != '' && i % 2 ? quoted.push(subs) : notQuoted.push(subs);
             });
-        } else notQuoted.push(s);
+        } else notQuoted.push(q);
 
         const regex = /"([^"]+)"|(\S{1,})/g;
         // Make sure that terms in quotes will be highlighted as one search term

--- a/verification/curator-service/ui/src/components/ViewCase.tsx
+++ b/verification/curator-service/ui/src/components/ViewCase.tsx
@@ -969,7 +969,9 @@ function RowContent(props: {
     const searchQueryArray: string[] = [];
 
     function words(s: string) {
-        if (s.startsWith('?q=')) s = s.substring(3);
+        if (s.includes('&q=')) {
+            s = s.split('&q=')[1];
+        } else if (s.includes('?q=')) s = s.substring(3);
 
         const quoted: string[] = [];
         const notQuoted: string[] = [];
@@ -979,7 +981,7 @@ function RowContent(props: {
             });
         } else notQuoted.push(s);
 
-        const regex = /"([^"]+)"|(\w{1,})/g;
+        const regex = /"([^"]+)"|(\S{1,})/g;
         // Make sure that terms in quotes will be highlighted as one search term
         for (const quotedEntry of quoted) {
             let match;


### PR DESCRIPTION
Solves: #98 

Changes:
* Free-text search now is capable of searching through the curator comments
* Highlighter now works with combinations of terms (quoted)
* DataGuideDialog component content was updated 

#### Screenshots:
Searching for a case with free-text (content in curators comment):
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/c4afc8a0-266b-48d6-9643-dde1c15c0c65">
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/5fb52838-c6c3-4a69-a9a4-09d894a30296">

Updated DataGuideDialog content:
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/c9338d9a-4ff2-4f50-a716-c73b678fd97c">

