### PR TITLE
[104] change date format

### DIFF
--- a/data-serving/data-service/src/controllers/case.ts
+++ b/data-serving/data-service/src/controllers/case.ts
@@ -352,6 +352,14 @@ export class CasesController {
                         header: false,
                         columns: this.csvHeaders,
                         delimiter: delimiter,
+                        cast: {
+                            date: (value: Date) => {
+                                if (value) {
+                                    return new Date(value).toISOString().split('T')[0];
+                                }
+                                return value;
+                            },
+                        }
                     });
                     res.write(stringifiedCase);
                     doc = await cursor.next();

--- a/data-serving/data-service/src/util/case.ts
+++ b/data-serving/data-service/src/util/case.ts
@@ -178,9 +178,8 @@ function denormalizeCaseReferenceFields(
             additionalSources.push(source.sourceUrl);
         }
     }
-    denormalizedData[
-        'caseReference.additionalSources'
-    ] = additionalSources.join(',');
+    denormalizedData['caseReference.additionalSources'] =
+        additionalSources.join(',');
     denormalizedData['caseReference.sourceEntryId'] = doc.sourceEntryId || '';
     denormalizedData['caseReference.sourceId'] = doc.sourceId || '';
     denormalizedData['caseReference.sourceUrl'] = doc.sourceUrl || '';
@@ -211,38 +210,40 @@ export const denormalizeEventsFields = (
     const denormalizedData: Record<string, string> = {};
 
     denormalizedData['events.dateEntry'] = doc.dateEntry
-        ? doc.dateEntry.toDateString()
+        ? doc.dateEntry.toISOString().split('T')[0]
         : undefined || '';
     denormalizedData['events.dateReported'] = doc.dateReported
-        ? doc.dateReported.toDateString()
+        ? doc.dateReported.toISOString().split('T')[0]
         : undefined || '';
-    denormalizedData['events.dateOnset'] = doc.dateOnset?.toDateString() || '';
+    denormalizedData['events.dateOnset'] =
+        doc.dateOnset?.toISOString().split('T')[0] || '';
     denormalizedData['events.dateConfirmation'] =
-        doc.dateConfirmation?.toDateString() || '';
+        doc.dateConfirmation?.toISOString().split('T')[0] || '';
     denormalizedData['events.confirmationMethod'] =
         doc.confirmationMethod || '';
     denormalizedData['events.dateOfFirstConsult'] =
-        doc.dateOfFirstConsult?.toDateString() || '';
+        doc.dateOfFirstConsult?.toISOString().split('T')[0] || '';
     denormalizedData['events.hospitalized'] = doc.hospitalized || '';
     denormalizedData['events.reasonForHospitalization'] =
         doc.reasonForHospitalization || '';
     denormalizedData['events.dateHospitalization'] =
-        doc.dateHospitalization?.toDateString() || '';
+        doc.dateHospitalization?.toISOString().split('T')[0] || '';
     denormalizedData['events.dateDischargeHospital'] =
-        doc.dateDischargeHospital?.toDateString() || '';
+        doc.dateDischargeHospital?.toISOString().split('T')[0] || '';
     denormalizedData['events.intensiveCare'] = doc.intensiveCare || '';
     denormalizedData['events.dateAdmissionICU'] =
-        doc.dateAdmissionICU?.toDateString() || '';
+        doc.dateAdmissionICU?.toISOString().split('T')[0] || '';
     denormalizedData['events.dateDischargeICU'] =
-        doc.dateDischargeICU?.toDateString() || '';
+        doc.dateDischargeICU?.toISOString().split('T')[0] || '';
     denormalizedData['events.homeMonitoring'] = doc.homeMonitoring || '';
     denormalizedData['events.isolated'] = doc.isolated || '';
     denormalizedData['events.dateIsolation'] =
-        doc.dateIsolation?.toDateString() || '';
+        doc.dateIsolation?.toISOString().split('T')[0] || '';
     denormalizedData['events.outcome'] = doc.outcome || '';
-    denormalizedData['events.dateDeath'] = doc.dateDeath?.toDateString() || '';
+    denormalizedData['events.dateDeath'] =
+        doc.dateDeath?.toISOString().split('T')[0] || '';
     denormalizedData['events.dateRecovered'] =
-        doc.dateRecovered?.toDateString() || '';
+        doc.dateRecovered?.toISOString().split('T')[0] || '';
 
     return denormalizedData;
 };
@@ -334,7 +335,7 @@ function denormalizeTravelHistoryFields(
 
     denormalizedData['travelHistory.travelHistory'] = doc?.travelHistory || '';
     denormalizedData['travelHistory.travelHistoryEntry'] =
-        doc?.travelHistoryEntry?.toDateString() || '';
+        doc?.travelHistoryEntry?.toISOString().split('T')[0] || '';
     denormalizedData['travelHistory.travelHistoryStart'] =
         doc?.travelHistoryStart || '';
     denormalizedData['travelHistory.travelHistoryLocation'] =
@@ -353,7 +354,7 @@ function denormalizeVaccineFields(
     denormalizedData['vaccination.vaccination'] = doc?.vaccination || '';
     denormalizedData['vaccination.vaccineName'] = doc?.vaccineName || '';
     denormalizedData['vaccination.vaccineDate'] =
-        doc?.vaccineDate?.toDateString() || '';
+        doc?.vaccineDate?.toISOString().split('T')[0] || '';
     denormalizedData['vaccination.vaccineSideEffects'] =
         doc?.vaccineSideEffects || '';
 

--- a/data-serving/data-service/src/util/case.ts
+++ b/data-serving/data-service/src/util/case.ts
@@ -103,6 +103,11 @@ export const removeBlankHeader = (headers: string[]): string[] => {
     return headers;
 };
 
+export const formatDateWithoutTime = (date: Date | undefined): string => {
+    if (!date) return '';
+    return date.toISOString().split('T')[0];
+};
+
 export const denormalizeFields = async (
     doc: CaseDocument,
 ): Promise<Partial<CaseDocument>> => {
@@ -210,40 +215,46 @@ export const denormalizeEventsFields = (
     const denormalizedData: Record<string, string> = {};
 
     denormalizedData['events.dateEntry'] = doc.dateEntry
-        ? doc.dateEntry.toISOString().split('T')[0]
+        ? formatDateWithoutTime(doc.dateEntry)
         : undefined || '';
     denormalizedData['events.dateReported'] = doc.dateReported
-        ? doc.dateReported.toISOString().split('T')[0]
+        ? formatDateWithoutTime(doc.dateReported)
         : undefined || '';
-    denormalizedData['events.dateOnset'] =
-        doc.dateOnset?.toISOString().split('T')[0] || '';
-    denormalizedData['events.dateConfirmation'] =
-        doc.dateConfirmation?.toISOString().split('T')[0] || '';
+    denormalizedData['events.dateOnset'] = formatDateWithoutTime(doc.dateOnset);
+    denormalizedData['events.dateConfirmation'] = formatDateWithoutTime(
+        doc.dateConfirmation,
+    );
     denormalizedData['events.confirmationMethod'] =
         doc.confirmationMethod || '';
-    denormalizedData['events.dateOfFirstConsult'] =
-        doc.dateOfFirstConsult?.toISOString().split('T')[0] || '';
+    denormalizedData['events.dateOfFirstConsult'] = formatDateWithoutTime(
+        doc.dateOfFirstConsult,
+    );
     denormalizedData['events.hospitalized'] = doc.hospitalized || '';
     denormalizedData['events.reasonForHospitalization'] =
         doc.reasonForHospitalization || '';
-    denormalizedData['events.dateHospitalization'] =
-        doc.dateHospitalization?.toISOString().split('T')[0] || '';
-    denormalizedData['events.dateDischargeHospital'] =
-        doc.dateDischargeHospital?.toISOString().split('T')[0] || '';
+    denormalizedData['events.dateHospitalization'] = formatDateWithoutTime(
+        doc.dateHospitalization,
+    );
+    denormalizedData['events.dateDischargeHospital'] = formatDateWithoutTime(
+        doc.dateDischargeHospital,
+    );
     denormalizedData['events.intensiveCare'] = doc.intensiveCare || '';
-    denormalizedData['events.dateAdmissionICU'] =
-        doc.dateAdmissionICU?.toISOString().split('T')[0] || '';
-    denormalizedData['events.dateDischargeICU'] =
-        doc.dateDischargeICU?.toISOString().split('T')[0] || '';
+    denormalizedData['events.dateAdmissionICU'] = formatDateWithoutTime(
+        doc.dateAdmissionICU,
+    );
+    denormalizedData['events.dateDischargeICU'] = formatDateWithoutTime(
+        doc.dateDischargeICU,
+    );
     denormalizedData['events.homeMonitoring'] = doc.homeMonitoring || '';
     denormalizedData['events.isolated'] = doc.isolated || '';
-    denormalizedData['events.dateIsolation'] =
-        doc.dateIsolation?.toISOString().split('T')[0] || '';
+    denormalizedData['events.dateIsolation'] = formatDateWithoutTime(
+        doc.dateIsolation,
+    );
     denormalizedData['events.outcome'] = doc.outcome || '';
-    denormalizedData['events.dateDeath'] =
-        doc.dateDeath?.toISOString().split('T')[0] || '';
-    denormalizedData['events.dateRecovered'] =
-        doc.dateRecovered?.toISOString().split('T')[0] || '';
+    denormalizedData['events.dateDeath'] = formatDateWithoutTime(doc.dateDeath);
+    denormalizedData['events.dateRecovered'] = formatDateWithoutTime(
+        doc.dateRecovered,
+    );
 
     return denormalizedData;
 };
@@ -335,7 +346,7 @@ function denormalizeTravelHistoryFields(
 
     denormalizedData['travelHistory.travelHistory'] = doc?.travelHistory || '';
     denormalizedData['travelHistory.travelHistoryEntry'] =
-        doc?.travelHistoryEntry?.toISOString().split('T')[0] || '';
+        formatDateWithoutTime(doc?.travelHistoryEntry);
     denormalizedData['travelHistory.travelHistoryStart'] =
         doc?.travelHistoryStart || '';
     denormalizedData['travelHistory.travelHistoryLocation'] =
@@ -353,8 +364,9 @@ function denormalizeVaccineFields(
 
     denormalizedData['vaccination.vaccination'] = doc?.vaccination || '';
     denormalizedData['vaccination.vaccineName'] = doc?.vaccineName || '';
-    denormalizedData['vaccination.vaccineDate'] =
-        doc?.vaccineDate?.toISOString().split('T')[0] || '';
+    denormalizedData['vaccination.vaccineDate'] = formatDateWithoutTime(
+        doc?.vaccineDate,
+    );
     denormalizedData['vaccination.vaccineSideEffects'] =
         doc?.vaccineSideEffects || '';
 

--- a/data-serving/data-service/test/util/case.test.ts
+++ b/data-serving/data-service/test/util/case.test.ts
@@ -421,16 +421,16 @@ describe('Case', () => {
         const denormalizedCase = await denormalizeFields(caseDoc);
 
         expect(denormalizedCase['events.dateEntry']).toEqual(
-            eventsDoc.dateEntry.toDateString(),
+            eventsDoc.dateEntry.toISOString().split('T')[0],
         );
         expect(denormalizedCase['events.dateReported']).toEqual(
-            eventsDoc.dateReported.toDateString(),
+            eventsDoc.dateReported.toISOString().split('T')[0],
         );
         expect(denormalizedCase['events.dateOnset']).toEqual(
-            eventsDoc.dateOnset?.toDateString(),
+            eventsDoc.dateOnset?.toISOString().split('T')[0],
         );
         expect(denormalizedCase['events.dateConfirmation']).toEqual(
-            eventsDoc.dateConfirmation?.toDateString(),
+            eventsDoc.dateConfirmation?.toISOString().split('T')[0],
         );
         expect(denormalizedCase['events.confirmationMethod']).toEqual('');
         expect(denormalizedCase['events.dateOfFirstConsult']).toEqual('');
@@ -612,7 +612,7 @@ describe('Case', () => {
 
         expect(denormalizedCase['travelHistory.travelHistory']).toEqual('Y');
         expect(denormalizedCase['travelHistory.travelHistoryEntry']).toEqual(
-            travelHistoryDoc.travelHistoryEntry.toDateString(),
+            travelHistoryDoc.travelHistoryEntry.toISOString().split('T')[0],
         );
         expect(denormalizedCase['travelHistory.travelHistoryStart']).toEqual(
             'start',
@@ -652,7 +652,7 @@ describe('Case', () => {
         expect(denormalizedCase['vaccination.vaccination']).toEqual('Y');
         expect(denormalizedCase['vaccination.vaccineName']).toEqual('Pfizer');
         expect(denormalizedCase['vaccination.vaccineDate']).toEqual(
-            vaccinationDoc.vaccineDate.toDateString(),
+            vaccinationDoc.vaccineDate.toISOString().split('T')[0],
         );
         expect(denormalizedCase['vaccination.vaccineSideEffects']).toEqual(
             'cough',

--- a/data-serving/data-service/test/util/case.test.ts
+++ b/data-serving/data-service/test/util/case.test.ts
@@ -13,7 +13,11 @@ import { RevisionMetadataDocument } from '../model/revision-metadata';
 import { TransmissionDocument } from '../model/transmission';
 import { TravelHistoryDocument } from '../model/travel-history';
 import { VaccineDocument } from '../model/vaccine';
-import { removeBlankHeader, denormalizeFields } from '../../src/util/case';
+import {
+    removeBlankHeader,
+    denormalizeFields,
+    formatDateWithoutTime,
+} from '../../src/util/case';
 import mongoose from 'mongoose';
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import { GenomeSequenceDocument } from '../../src/model/genome-sequence';
@@ -421,16 +425,16 @@ describe('Case', () => {
         const denormalizedCase = await denormalizeFields(caseDoc);
 
         expect(denormalizedCase['events.dateEntry']).toEqual(
-            eventsDoc.dateEntry.toISOString().split('T')[0],
+            formatDateWithoutTime(eventsDoc.dateEntry),
         );
         expect(denormalizedCase['events.dateReported']).toEqual(
-            eventsDoc.dateReported.toISOString().split('T')[0],
+            formatDateWithoutTime(eventsDoc.dateReported),
         );
         expect(denormalizedCase['events.dateOnset']).toEqual(
-            eventsDoc.dateOnset?.toISOString().split('T')[0],
+            formatDateWithoutTime(eventsDoc.dateOnset),
         );
         expect(denormalizedCase['events.dateConfirmation']).toEqual(
-            eventsDoc.dateConfirmation?.toISOString().split('T')[0],
+            formatDateWithoutTime(eventsDoc.dateConfirmation),
         );
         expect(denormalizedCase['events.confirmationMethod']).toEqual('');
         expect(denormalizedCase['events.dateOfFirstConsult']).toEqual('');
@@ -612,7 +616,7 @@ describe('Case', () => {
 
         expect(denormalizedCase['travelHistory.travelHistory']).toEqual('Y');
         expect(denormalizedCase['travelHistory.travelHistoryEntry']).toEqual(
-            travelHistoryDoc.travelHistoryEntry.toISOString().split('T')[0],
+            formatDateWithoutTime(travelHistoryDoc.travelHistoryEntry),
         );
         expect(denormalizedCase['travelHistory.travelHistoryStart']).toEqual(
             'start',
@@ -652,7 +656,7 @@ describe('Case', () => {
         expect(denormalizedCase['vaccination.vaccination']).toEqual('Y');
         expect(denormalizedCase['vaccination.vaccineName']).toEqual('Pfizer');
         expect(denormalizedCase['vaccination.vaccineDate']).toEqual(
-            vaccinationDoc.vaccineDate.toISOString().split('T')[0],
+            formatDateWithoutTime(vaccinationDoc.vaccineDate),
         );
         expect(denormalizedCase['vaccination.vaccineSideEffects']).toEqual(
             'cough',
@@ -688,5 +692,14 @@ describe('Case', () => {
         expect(denormalizedCase['genomeSequences.accessionNumber']).toEqual(
             '1234',
         );
+    });
+
+    it.only('formatsDateWithoutTimeCorrectly', async () => {
+        const correctDateString = '2024-01-01';
+        const correctDate = new Date(`${correctDateString}T03:24:00`);
+        const missingDate = undefined;
+
+        expect(formatDateWithoutTime(correctDate)).toEqual(correctDateString);
+        expect(formatDateWithoutTime(missingDate)).toEqual('');
     });
 });

--- a/data-serving/data-service/test/util/case.test.ts
+++ b/data-serving/data-service/test/util/case.test.ts
@@ -694,7 +694,7 @@ describe('Case', () => {
         );
     });
 
-    it.only('formatsDateWithoutTimeCorrectly', async () => {
+    it('formatsDateWithoutTimeCorrectly', async () => {
         const correctDateString = '2024-01-01';
         const correctDate = new Date(`${correctDateString}T03:24:00`);
         const missingDate = undefined;


### PR DESCRIPTION
Solves: #104

Changes:
* Make all dates in downloads follow 'YYYY-MM-DD' pattern

#### Verification:

<img width="1728" alt="Screenshot 2024-11-01 at 13 53 35" src="https://github.com/user-attachments/assets/8d49288c-d4ea-467a-a7ea-48db6d597bd3">

**WARNING**
This task must not be verified using the `DOWNLOAD FULL DATASET` as the data for this download is prepared by the external service.
<img width="600" alt="image" src="https://github.com/user-attachments/assets/a14ff502-27d9-43a0-9d87-c94b91999bb5">

#### Screenshots:
Was:
<img width="658" alt="image" src="https://github.com/user-attachments/assets/dab8cb7f-cdde-440e-a3da-0448aea95ed4">

Is:
<img width="537" alt="image" src="https://github.com/user-attachments/assets/5973db0b-85a9-468a-86e1-3ca609b4a4c7">
