### PR TITLE
Do not export fields with casereference metadata meaningless for users

### DIFF
--- a/data-serving/scripts/export-data/fields.txt
+++ b/data-serving/scripts/export-data/fields.txt
@@ -1,9 +1,6 @@
 _id
-caseReference.sourceId
-caseReference.sourceEntryId
 caseReference.sourceUrl
 caseReference.isGovernmentSource
-caseReference.uploadIds
 caseReference.additionalSources
 caseStatus
 demographics.ageRange.start


### PR DESCRIPTION
Solves: #103 

#### How it looked like:
<img width="1369" alt="image" src="https://github.com/user-attachments/assets/822fb628-63e2-4de3-bcbe-1a91a0da16d1" />

#### Changes:
* Do not export `sourceId`, `sourceEntryId` and `uploadIds` fields.

#### Testing:
Changes made to the exporter can be tested on [this deployment](https://dry-run-dev-data.covid-19.global.health).

##### Steps:
1) Download dataset
<img width="1728" alt="Screenshot 2025-01-17 at 14 34 51" src="https://github.com/user-attachments/assets/f375c75e-66ca-44dd-94f1-a24cae8d74a6" />
<img width="599" alt="Screenshot 2025-01-17 at 14 35 23" src="https://github.com/user-attachments/assets/b71de60e-6265-48e7-ac7c-9296375dc7a8" />

2) Unzip downloaded file: 
```
gzip -d <<filename>>
```

3) Check that file does not contain `sourceId`, `sourceEntryId` or `uploadIds` columns:

<img width="845" alt="image" src="https://github.com/user-attachments/assets/19fda0c9-815a-4593-ad70-9decf78da565" />

